### PR TITLE
add multi-arch release builds and systemd service support. Fix installer script. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,18 @@ jobs:
           govulncheck ./...
 
   build:
-    name: Build
+    name: Build (${{ matrix.os }}_${{ matrix.arch }})
     runs-on: ubuntu-latest
     needs: [lint, security-scan, test]
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            goarch: amd64
+          - os: linux
+            arch: arm64
+            goarch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -119,15 +128,35 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libpcsclite-dev
+          # Install cross-compilation toolchain for arm64
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+          fi
+
+      - name: Setup dev environment
+        run: |
+          mkdir .build
+          git clone --branch v0.29.0 --depth 1 https://github.com/smallstep/certificates.git .build/certificates/
+          rm -rf .build/certificates/server && cp -r ./hack/server .build/certificates/server
+          mkdir -p db
+          go mod tidy
 
       - name: Build binary
-        run: make
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: ${{ matrix.arch == 'arm64' && '0' || '1' }}
+          CC: ${{ matrix.arch == 'arm64' && 'aarch64-linux-gnu-gcc' || '' }}
+        run: |
+          BINARY_NAME="step-ca_${{ matrix.os }}_${{ matrix.arch }}"
+          go build -v -o "${BINARY_NAME}" .
+          echo "Built ${BINARY_NAME}"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: step-ca-linux-amd64
-          path: step-ca
+          name: step-ca_${{ matrix.os }}_${{ matrix.arch }}
+          path: step-ca_${{ matrix.os }}_${{ matrix.arch }}
 
   container-build-and-push:
     name: Build and Push Container
@@ -184,18 +213,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          path: dist
+          pattern: step-ca_*
+          merge-multiple: true
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libpcsclite-dev
-
-      - name: Build binary
-        run: make
+      - name: List artifacts
+        run: ls -la dist/
 
       - name: Get version
         id: version
@@ -207,6 +233,6 @@ jobs:
           name: Release ${{ steps.version.outputs.VERSION }}
           generate_release_notes: true
           files: |
-            step-ca
+            dist/step-ca_*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The most important part of the config is this section
 
 `ca_url` : ACME directory URL of external certificate authority. To get signed certs from InCommon use `https://acme.sectigo.com/v2/InCommonRSAOV`
 
-Many commercial certificate authorities support ACME over external account binding (EAB). You will need to create an EAB token to get HMAC Key and Key ID related to your account.
+Most commercial certificate authorities (such as Sectigo) support ACME over external account binding (EAB). You will need to  to get your EAB credentials i.e HMAC Key and Key ID related to your account.
 
 ```json
   "account_email": "admin@example.com",
@@ -76,7 +76,7 @@ Many commercial certificate authorities support ACME over external account bindi
 
 ### Starting the ACME server
 
-Upon starting the ACME server it automatically obtains a SSL/TLS certificate from InCommon for itself
+Upon starting the ACME server it automatically obtains a SSL/TLS certificate for itself.
 
 ```sh
 $ ./step-ca ca.json
@@ -192,7 +192,7 @@ We have our certificate signed by InCommon 🎉
 
 ### Renewing a certificate
 
-Issuing a certificate is _generally_ not a problem. It's the ability to renew a certificate and reload services post renewal and doing so in a consistent and reliable way is usually the problem. The certificate we obtained above has validity for 13 months! I am using the `--force` flag for renewal only because the default configuration in ACME clients only performs automatic renewal `1 < N < 30` number of days before certificate expiration. This default behaviour can be changed if needed, I think.
+Issuing a certificate is _generally_ not a problem in enterprise environments. But the ability to reliably renew certificates and reload services gracefully post renewal is. I am using the `--force` flag for renewal only because the default configuration in ACME clients only performs automatic renewal `1 < N < 30` number of days before certificate expiration.
 
 ```sh
 $ ./acme.sh --renew --domain myserver.example.com --force

--- a/acmeproxy.service
+++ b/acmeproxy.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=ACME Proxy Server (step-ca)
+Documentation=https://github.com/esnet/acme-proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=acmeproxy
+Group=acmeproxy
+
+# Paths
+ExecStart=/usr/local/bin/step-ca /etc/acmeproxy/ca.json
+WorkingDirectory=/etc/acmeproxy
+
+# Restart behavior
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+
+# Allow binding to privileged ports (443)
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+# Allow write access to config and database directories
+ReadWritePaths=/etc/acmeproxy
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=acmeproxy
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- CI: build binaries for linux/amd64 and linux/arm64 architectures
- CI: use step-ca_${OS}_${ARCH} naming pattern for release binaries
- installer: add systemd service with security hardening
- installer: create dedicated acmeproxy user and enable service
- installer: fix binary name from acme-proxy to step-ca
- docs: minor README wording improvements