### PR TITLE
fix(ansible): add become, gate pcsclite install, fix package names

### DIFF
--- a/ansible/roles/acme-proxy/defaults/main.yml
+++ b/ansible/roles/acme-proxy/defaults/main.yml
@@ -33,6 +33,12 @@ acme_proxy_tls_min_version: 1.2
 acme_proxy_tls_max_version: 1.3
 acme_proxy_tls_renegotiation: false
 
+# Dependencies
+# The pre-built binary is dynamically linked against libpcsclite.
+# Set to false only if you have verified the library is already present
+# or are supplying a statically-linked binary.
+acme_proxy_install_pcsc: true
+
 # Systemd service state
 acme_proxy_service_enabled: true
 acme_proxy_service_state: started

--- a/ansible/roles/acme-proxy/handlers/main.yml
+++ b/ansible/roles/acme-proxy/handlers/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: reload systemd daemon
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
 
 - name: restart acme-proxy
+  become: true
   ansible.builtin.systemd:
     name: acme-proxy
     state: restarted

--- a/ansible/roles/acme-proxy/tasks/binary.yml
+++ b/ansible/roles/acme-proxy/tasks/binary.yml
@@ -14,12 +14,16 @@
          else acme_proxy_version }}
 
 - name: Read installed version file
+  become: true
+  become_user: "{{ acme_proxy_service_user }}"
   ansible.builtin.slurp:
     src: "{{ acme_proxy_install_dir }}/.version"
   register: _acme_proxy_version_file
   ignore_errors: true
 
 - name: Download acme-proxy binary
+  become: true
+  become_user: "{{ acme_proxy_service_user }}"
   ansible.builtin.get_url:
     url: >-
       https://github.com/esnet/acme-proxy/releases/download/{{ _acme_proxy_resolved_version }}/step-ca_{{ ansible_system | lower }}_{{ _acme_proxy_arch }}
@@ -33,6 +37,8 @@
   notify: restart acme-proxy
 
 - name: Record installed version
+  become: true
+  become_user: "{{ acme_proxy_service_user }}"
   ansible.builtin.copy:
     content: "{{ _acme_proxy_resolved_version }}"
     dest: "{{ acme_proxy_install_dir }}/.version"

--- a/ansible/roles/acme-proxy/tasks/configure.yml
+++ b/ansible/roles/acme-proxy/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
 - name: Deploy ca.json configuration
+  become: true
   ansible.builtin.template:
     src: ca.json.j2
     dest: "{{ acme_proxy_config_file }}"

--- a/ansible/roles/acme-proxy/tasks/directories.yml
+++ b/ansible/roles/acme-proxy/tasks/directories.yml
@@ -1,5 +1,6 @@
 ---
 - name: Create installation directories
+  become: true
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory

--- a/ansible/roles/acme-proxy/tasks/packages.yml
+++ b/ansible/roles/acme-proxy/tasks/packages.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install libpcsclite dependency
+  become: true
   ansible.builtin.package:
     name: "{{ _acme_proxy_pcsc_packages[ansible_os_family] }}"
     state: present
-  when: ansible_os_family in _acme_proxy_pcsc_packages
+  when:
+    - acme_proxy_install_pcsc
+    - ansible_os_family in _acme_proxy_pcsc_packages

--- a/ansible/roles/acme-proxy/tasks/service.yml
+++ b/ansible/roles/acme-proxy/tasks/service.yml
@@ -1,5 +1,6 @@
 ---
 - name: Deploy systemd unit
+  become: true
   ansible.builtin.template:
     src: acme-proxy.service.j2
     dest: /etc/systemd/system/acme-proxy.service
@@ -11,6 +12,7 @@
     - restart acme-proxy
 
 - name: Enable and manage acme-proxy service
+  become: true
   ansible.builtin.systemd:
     name: acme-proxy
     enabled: "{{ acme_proxy_service_enabled }}"

--- a/ansible/roles/acme-proxy/tasks/user.yml
+++ b/ansible/roles/acme-proxy/tasks/user.yml
@@ -1,11 +1,13 @@
 ---
 - name: Create service group
+  become: true
   ansible.builtin.group:
     name: "{{ acme_proxy_service_group }}"
     system: true
     state: present
 
 - name: Create service user
+  become: true
   ansible.builtin.user:
     name: "{{ acme_proxy_service_user }}"
     group: "{{ acme_proxy_service_group }}"

--- a/ansible/roles/acme-proxy/vars/main.yml
+++ b/ansible/roles/acme-proxy/vars/main.yml
@@ -7,5 +7,5 @@ _acme_proxy_arch_map:
 _acme_proxy_arch: "{{ _acme_proxy_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 _acme_proxy_pcsc_packages:
-  Debian: libpcsclite-dev
-  RedHat: pcsc-lite-devel
+  Debian: libpcsclite1
+  RedHat: pcsc-lite


### PR DESCRIPTION
## Summary

- **become**: The role runs system-level operations (package install, user/group
  creation, directory creation, binary download, systemd management) but declared
  no `become: true` on any task or handler, causing failures when Ansible connects
  as an unprivileged user. Added `become: true` to all tasks that require root, and
  to both handlers (which do not inherit `become` from the notifying task).

- **become_user**: The binary install tasks (`slurp`, `get_url`, `copy`) now use
  `become_user: acme-proxy`. The install directory is mode `0750` owned by the
  service user, so temp file creation fails when running as root.

- **libpcsclite**: Added `acme_proxy_install_pcsc` (default: `true`) to gate the
  package install. Despite the docs stating libpcsclite is only required for source
  builds, the pre-built binary is dynamically linked against `libpcsclite.so.1` and
  will not start without it (`error while loading shared libraries: libpcsclite.so.1`).
  Also corrected the package names from build-time devel packages to the runtime
  libraries: `pcsc-lite-devel` → `pcsc-lite` (RedHat), `libpcsclite-dev` →
  `libpcsclite1` (Debian).

## Test plan

- [ ] Run role against an EL9 host as an unprivileged Ansible user — all tasks
      complete without privilege errors
- [ ] Verify `acme-proxy.service` starts cleanly (`libpcsclite.so.1` found)
- [ ] Run with `--check --diff` — no live GitHub API call when version is pinned
- [ ] Set `acme_proxy_install_pcsc: false` — package task is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)