### PR TITLE
externalcas: make the certificate obtain timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ To get certificates signed from LetsEncrypt use the following config options
 | `dns01_txt.provider`    | [Lego Provider](https://go-acme.github.io/lego/dns/index.html) CLI Flag name |
 | `dns01_txt.dns_servers` | Use your authoritative DNS server's addresses to avoid caching/TTL problems  |
 | `dns01_txt.env_vars`    | Environment variables specific to your Lego DNS Provider for authentication  |
+| `cert_obtain_timeout`   | Seconds to wait for the CA to issue the certificate after finalization (default `30`). Raise it if your CA's post-finalization checks take longer — e.g. CertiNext can exceed 30s — otherwise the order fails with `certificate: time limit exceeded` while the CA still issues the cert. Must be below 120 |
 
 
 ### Starting acme-proxy

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ To get certificates signed from LetsEncrypt use the following config options
 | `dns01_txt.provider`    | [Lego Provider](https://go-acme.github.io/lego/dns/index.html) CLI Flag name |
 | `dns01_txt.dns_servers` | Use your authoritative DNS server's addresses to avoid caching/TTL problems  |
 | `dns01_txt.env_vars`    | Environment variables specific to your Lego DNS Provider for authentication  |
-| `cert_obtain_timeout`   | Seconds to wait for the CA to issue the certificate after finalization (default `30`). Raise it if your CA's post-finalization checks take longer — e.g. CertiNext can exceed 30s — otherwise the order fails with `certificate: time limit exceeded` while the CA still issues the cert. Must be below 120 |
+| `cert_obtain_timeout`   | Seconds to wait for the CA to issue the certificate after finalization (default `30`). Raise it if your CA's post-finalization checks take longer — otherwise the order fails with `certificate: time limit exceeded` while the CA still issues the cert. CertiNext currently recommends `300` while a CT log operator delays their 30-day product. Must be below `request_timeout` |
+| `request_timeout`       | Seconds the whole certificate request may take end to end — registration, authorizations, finalization and the wait above (default `120`). Raise it together with `cert_obtain_timeout`, e.g. `330` for a `300` wait |
 
 
 ### Starting acme-proxy

--- a/externalcas/config.go
+++ b/externalcas/config.go
@@ -37,8 +37,13 @@ type acmeProxyConfig struct {
 	// Seconds to wait for the external CA to issue the certificate after the order
 	// is finalized (optional, default 30 — lego's default). Some CAs run
 	// post-finalization checks that take longer than that; must stay below
-	// RequestTimeout so the outer context still bounds the whole request.
+	// request_timeout so the outer context still bounds the whole request.
 	CertObtainTimeout int `json:"cert_obtain_timeout,omitempty"`
+
+	// Seconds the whole certificate request may take end to end — account
+	// registration, authorizations, finalization and the wait above (optional,
+	// default 120). Raise it together with cert_obtain_timeout.
+	RequestTimeoutSec int `json:"request_timeout,omitempty"`
 
 	// Lego provider connection variables for dns01 TXT challenge
 	Lego legoConfig `json:"dns01_txt"`
@@ -73,8 +78,11 @@ func (c *acmeProxyConfig) Validate() error {
 	if c.CertObtainTimeout < 0 {
 		return errors.New("cert_obtain_timeout cannot be negative")
 	}
+	if c.RequestTimeoutSec < 0 {
+		return errors.New("request_timeout cannot be negative")
+	}
 	if c.ObtainTimeout() >= c.RequestTimeout() {
-		return fmt.Errorf("cert_obtain_timeout must be less than the request timeout (%s)", c.RequestTimeout())
+		return fmt.Errorf("cert_obtain_timeout (%s) must be less than request_timeout (%s)", c.ObtainTimeout(), c.RequestTimeout())
 	}
 
 	// Consider Metrics enabled only when port & datasource both are defined
@@ -95,7 +103,10 @@ func (c *acmeProxyConfig) HTTPTimeout() time.Duration {
 
 // RequestTimeout returns the timeout for certificate request operations
 func (c *acmeProxyConfig) RequestTimeout() time.Duration {
-	return 2 * time.Minute
+	if c.RequestTimeoutSec <= 0 {
+		return 2 * time.Minute
+	}
+	return time.Duration(c.RequestTimeoutSec) * time.Second
 }
 
 // ObtainTimeout returns how long lego waits for the external CA to issue the

--- a/externalcas/config.go
+++ b/externalcas/config.go
@@ -34,6 +34,12 @@ type acmeProxyConfig struct {
 	// Certificate lifetime in days (optional)
 	CertLifetime int `json:"certlifetime,omitempty"`
 
+	// Seconds to wait for the external CA to issue the certificate after the order
+	// is finalized (optional, default 30 — lego's default). Some CAs run
+	// post-finalization checks that take longer than that; must stay below
+	// RequestTimeout so the outer context still bounds the whole request.
+	CertObtainTimeout int `json:"cert_obtain_timeout,omitempty"`
+
 	// Lego provider connection variables for dns01 TXT challenge
 	Lego legoConfig `json:"dns01_txt"`
 
@@ -64,6 +70,12 @@ func (c *acmeProxyConfig) Validate() error {
 	if c.CertLifetime < 0 {
 		return errors.New("certlifetime cannot be negative")
 	}
+	if c.CertObtainTimeout < 0 {
+		return errors.New("cert_obtain_timeout cannot be negative")
+	}
+	if c.ObtainTimeout() >= c.RequestTimeout() {
+		return fmt.Errorf("cert_obtain_timeout must be less than the request timeout (%s)", c.RequestTimeout())
+	}
 
 	// Consider Metrics enabled only when port & datasource both are defined
 	if c.Metrics.Port > 0 && c.Metrics.DataSource != "" {
@@ -84,6 +96,15 @@ func (c *acmeProxyConfig) HTTPTimeout() time.Duration {
 // RequestTimeout returns the timeout for certificate request operations
 func (c *acmeProxyConfig) RequestTimeout() time.Duration {
 	return 2 * time.Minute
+}
+
+// ObtainTimeout returns how long lego waits for the external CA to issue the
+// certificate after finalization
+func (c *acmeProxyConfig) ObtainTimeout() time.Duration {
+	if c.CertObtainTimeout <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(c.CertObtainTimeout) * time.Second
 }
 
 // parseConfig is a helper function which reads ca.json file as rawjson and validates

--- a/externalcas/config_test.go
+++ b/externalcas/config_test.go
@@ -77,7 +77,7 @@ func TestAcmeProxyConfig_Validate(t *testing.T) {
 				CertObtainTimeout: 120,
 			},
 			wantErr: true,
-			errMsg:  "cert_obtain_timeout must be less than the request timeout (2m0s)",
+			errMsg:  "cert_obtain_timeout (2m0s) must be less than request_timeout (2m0s)",
 		},
 		{
 			name: "cert_obtain_timeout below request timeout is valid",
@@ -88,6 +88,40 @@ func TestAcmeProxyConfig_Validate(t *testing.T) {
 				CertObtainTimeout: 90,
 			},
 			wantErr: false,
+		},
+		{
+			name: "negative request_timeout",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				RequestTimeoutSec: -1,
+			},
+			wantErr: true,
+			errMsg:  "request_timeout cannot be negative",
+		},
+		{
+			name: "cert_obtain_timeout above default request timeout is valid when request_timeout is raised",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				CertObtainTimeout: 300,
+				RequestTimeoutSec: 330,
+			},
+			wantErr: false,
+		},
+		{
+			name: "cert_obtain_timeout at a raised request_timeout is rejected",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				CertObtainTimeout: 330,
+				RequestTimeoutSec: 330,
+			},
+			wantErr: true,
+			errMsg:  "cert_obtain_timeout (5m30s) must be less than request_timeout (5m30s)",
 		},
 		{
 			name: "metrics enabled without valid datasource",
@@ -215,6 +249,12 @@ func TestAcmeProxyConfig_Timeouts(t *testing.T) {
 	obtainTimeout = config.ObtainTimeout()
 	if obtainTimeout != 90*time.Second {
 		t.Errorf("ObtainTimeout() with cert_obtain_timeout=90 = %v, want %v", obtainTimeout, 90*time.Second)
+	}
+
+	config.RequestTimeoutSec = 330
+	requestTimeout = config.RequestTimeout()
+	if requestTimeout != 330*time.Second {
+		t.Errorf("RequestTimeout() with request_timeout=330 = %v, want %v", requestTimeout, 330*time.Second)
 	}
 }
 

--- a/externalcas/config_test.go
+++ b/externalcas/config_test.go
@@ -58,6 +58,38 @@ func TestAcmeProxyConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "negative cert_obtain_timeout",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				CertObtainTimeout: -1,
+			},
+			wantErr: true,
+			errMsg:  "cert_obtain_timeout cannot be negative",
+		},
+		{
+			name: "cert_obtain_timeout at or above request timeout",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				CertObtainTimeout: 120,
+			},
+			wantErr: true,
+			errMsg:  "cert_obtain_timeout must be less than the request timeout (2m0s)",
+		},
+		{
+			name: "cert_obtain_timeout below request timeout is valid",
+			config: acmeProxyConfig{
+				CaURL:             "https://acme.example.com",
+				Kid:               "test-kid",
+				HmacKey:           "test-hmac",
+				CertObtainTimeout: 90,
+			},
+			wantErr: false,
+		},
+		{
 			name: "metrics enabled without valid datasource",
 			config: acmeProxyConfig{
 				CaURL:   "https://acme.example.com",
@@ -172,6 +204,17 @@ func TestAcmeProxyConfig_Timeouts(t *testing.T) {
 	requestTimeout := config.RequestTimeout()
 	if requestTimeout != 2*time.Minute {
 		t.Errorf("RequestTimeout() = %v, want %v", requestTimeout, 2*time.Minute)
+	}
+
+	obtainTimeout := config.ObtainTimeout()
+	if obtainTimeout != 30*time.Second {
+		t.Errorf("ObtainTimeout() default = %v, want %v", obtainTimeout, 30*time.Second)
+	}
+
+	config.CertObtainTimeout = 90
+	obtainTimeout = config.ObtainTimeout()
+	if obtainTimeout != 90*time.Second {
+		t.Errorf("ObtainTimeout() with cert_obtain_timeout=90 = %v, want %v", obtainTimeout, 90*time.Second)
 	}
 }
 

--- a/externalcas/external.go
+++ b/externalcas/external.go
@@ -107,6 +107,7 @@ func (c *ExternalCAS) createLegoClient(cfg *acmeProxyConfig) (ACMEClient, error)
 	clientConfig := lego.NewConfig(user)
 	clientConfig.CADirURL = cfg.CaURL
 	clientConfig.Certificate.KeyType = certcrypto.EC256 // gitleaks:allow
+	clientConfig.Certificate.Timeout = cfg.ObtainTimeout()
 	clientConfig.HTTPClient = &http.Client{
 		Timeout: cfg.HTTPTimeout(),
 	}


### PR DESCRIPTION
Fixes #56. Follow-up to #22, which fixed the downstream half of the same root cause.

## Problem

`createLegoClient` in `externalcas/external.go` never sets `Certificate.Timeout`, so the wait for the upstream CA to issue the certificate after `/finalize` is capped at lego's 30s default — even though `RequestTimeout()` already allows 2 minutes for the whole request. CAs whose post-finalization checks exceed 30s (CertiNext/InCommon has confirmed theirs can) make async finalization fail with `certificate: time limit exceeded` while the CA still issues the certificate, so every client retry mints another uncollected cert.

## Change

- `externalcas/config.go`: new optional `cert_obtain_timeout` (seconds) on `authority.config`, with an `ObtainTimeout() time.Duration` accessor. **Default is 30s**, so existing deployments are unchanged. `Validate()` rejects negative values and values at or above `RequestTimeout()`, so the outer context still bounds the request.
- `externalcas/external.go`: `clientConfig.Certificate.Timeout = cfg.ObtainTimeout()`.
- `externalcas/config_test.go`: cases for the default, a configured value, and both validation errors.
- `README.md`: documents the field in the config table.

Example:

```json
"authority": {
  "type": "externalcas",
  "config": {
    "ca_url": "https://acme-us.certinext.io/v1/directory",
    "cert_obtain_timeout": 90,
    ...
  }
}
```

## Testing

`gofmt -l`, `go vet ./externalcas/`, and `go test ./...` are clean. We'll be running this against CertiNext production and can report back on the observed finalize-to-issue times.
